### PR TITLE
Add an NPM Ignore File

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.babelrc
+.gitignore
+./src
+./tests


### PR DESCRIPTION
We need to add an `.npmignore` to avoid publishing our `.babelrc` (and some other directories we don't need to be published won't hurt either).
